### PR TITLE
Added backup pruner cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
 # Tarsnapper pruner server
 
-Deploys a high-security server, has full access to most our tarsnapper backups. 
-This server is used only to delete old backups. 
+Deploys a high-security server, has full access to most our tarsnapper backups.
+This server is used only to delete old backups.
 
 How to deploy
 -------------
 
-1. Set IP in hosts 
-2. Download vault password 
-3. `deploy-all.yaml -u admin --vault-password-file .vault-pass`
+`ansible-playbook deploy/deploy-all.yml -u ubuntu --extra-vars @private-extra-vars.yml -i hosts --private-key /path/to/backup_pruner.key`
 
 How to add new backup to be pruned
 ----------------------------------
 
 1. Get master key
 2. Save master key to private.yml
-3. Save cache directory and file for tarsnap key in the private yaml 
+3. Save cache directory and file for tarsnap key in the private yaml
 4. Add new entry to `TARSNAPPER_JOBS`
 
-How to prune backups
---------------------
+How to prune backups for individual servers
+-------------------------------------------
 
-1. Login to the instance 
+1. Login to the instance
 2. Pruning scripts are named `tarsnap-{{ job.name }}.sh`
-3. Following operations are supported: 
+3. Following operations are supported:
    a. List archives `sudo tarsnap-{{ job.name }}.sh list`
    b. Expire archives `sudo tarsnap-{{ job.name }}.sh. expire`
    c. Expire archives (dry run) `tarsnap-{{ job.name }}.sh expire --dry-run`
-   

--- a/backup-pruner.yml
+++ b/backup-pruner.yml
@@ -52,6 +52,22 @@
   no_log: true
   with_items: "{{ TARSNAPPER_JOBS }}"
 
+- name: create log dir
+  file:
+    name: "{{ LOG_DIR }}"
+    owner: "root"
+    group: "root"
+    mode: "700"
+    state: directory
+
+- name: add logrotate for individual pruner logs
+  template:
+    src: "logrotate.conf"
+    dest: "/etc/logrotate.d/backup-pruner"
+    owner: "root"
+    group: "root"
+    mode: "644"
+
 - name: add parallel pruner script
   template:
     src: "backup-pruner.sh"

--- a/backup-pruner.yml
+++ b/backup-pruner.yml
@@ -1,4 +1,9 @@
 ---
+- name: install gnu parallel
+  apt:
+    name: parallel
+    state: present
+
 - name: create dirs
   file:
     name: "{{ item }}"
@@ -46,3 +51,18 @@
     mode: "700"
   no_log: true
   with_items: "{{ TARSNAPPER_JOBS }}"
+
+- name: add parallel pruner script
+  template:
+    src: "backup-pruner.sh"
+    dest: "{{ BACKUP_PRUNER_SCRIPT }}"
+    owner: "root"
+    group: "root"
+    mode: "700"
+
+- name: add backup pruner cron
+  cron:
+    name: "backup pruner"
+    minute: 40
+    hour: "6,18"
+    job: "{{ BACKUP_PRUNER_SCRIPT }}"

--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -12,6 +12,7 @@
   roles:
     - name: common-server
       COMMON_SERVER_NO_BACKUPS: true
+    - forward-server-mail
     - name: 'pmbauer.tarsnap'
 
 - name: Install backup pruner

--- a/host_vars/backup-pruner.opencraft.com/public.yml
+++ b/host_vars/backup-pruner.opencraft.com/public.yml
@@ -3,8 +3,10 @@ FORWARD_MAIL_RELAY_MAIL_TO: "ops@example.com"
 FORWARD_MAIL_SMTP_FROM: "{{ FORWARD_MAIL_RELAY_MAIL_TO }}"
 
 TARSNAPPER_CONF: /etc/tarsnapper.yml
-JOB_LOG: /var/log/backup_pruner.log
+JOB_LOG: /var/log/backup-pruner-summary.log
+LOG_DIR: /var/log/backup-pruner
 BACKUP_PRUNER_SCRIPT: /usr/local/sbin/backup-pruner.sh
+BACKUP_PRUNER_SNITCH: https://nosnch.in/5e416d313e
 
 # Can be changed to normal tarsnapper once we merge this branch
 # and code winds up on PIP

--- a/host_vars/pruner/public.yml
+++ b/host_vars/pruner/public.yml
@@ -3,6 +3,8 @@ FORWARD_MAIL_RELAY_MAIL_TO: "ops@example.com"
 FORWARD_MAIL_SMTP_FROM: "{{ FORWARD_MAIL_RELAY_MAIL_TO }}"
 
 TARSNAPPER_CONF: /etc/tarsnapper.yml
+JOB_LOG: /var/log/backup_pruner.log
+BACKUP_PRUNER_SCRIPT: /usr/local/sbin/backup-pruner.sh
 
 # Can be changed to normal tarsnapper once we merge this branch
 # and code winds up on PIP

--- a/templates/backup-pruner.sh
+++ b/templates/backup-pruner.sh
@@ -1,0 +1,17 @@
+#jinja2: trim_blocks:False
+#!/bin/bash
+# This script runs all of the backup pruners in parallel, returning the output
+# of only the failing pruners.
+# Check {{ JOB_LOG }} for a summary of the most recent pruner run.
+set -e
+
+jobs='{% for item in TARSNAPPER_JOBS %}
+{{ item.name }}{% endfor %}'
+
+# Buffer the output of each pruner per-task; if the pruner fails, forward along the
+# output to GNU Parallel, which will then simply forward the output along to cron.
+task='output=$(/usr/local/sbin/tarsnap-{}.sh expire 2>&1) || echo "$output"'
+# Cron will send email if there is any stdout or stderr output regardless of the
+# response code, so by only including output for failed tasks in the output, an
+# email will only be sent out if and only if one or more backup pruners failed.
+echo "$jobs" | tail -n +2 | parallel --no-notice -j0 --joblog {{ JOB_LOG }} $task

--- a/templates/backup-pruner.sh
+++ b/templates/backup-pruner.sh
@@ -3,15 +3,28 @@
 # This script runs all of the backup pruners in parallel, returning the output
 # of only the failing pruners.
 # Check {{ JOB_LOG }} for a summary of the most recent pruner run.
+# Check the {{ LOG_DIR }} for the full log of each pruning task.
 set -e
 
 jobs='{% for item in TARSNAPPER_JOBS %}
 {{ item.name }}{% endfor %}'
 
-# Buffer the output of each pruner per-task; if the pruner fails, forward along the
-# output to GNU Parallel, which will then simply forward the output along to cron.
-task='output=$(/usr/local/sbin/tarsnap-{}.sh expire 2>&1) || echo "$output"'
+# Buffer the output of each pruner per-task; if the pruner fails (returns a
+# non-zero exit status), forward along the output to GNU Parallel, which will
+# then simply forward the output along to cron.
+# The `test ${PIPESTATUS[0]} -eq 0` part is checking the return status of the
+# pruner script; this is necessary because we don't care about the return
+# status of `tee`, which will always be 0.
+task='output=$(/usr/local/sbin/tarsnap-{}.sh expire 2>&1 | tee -a {{ LOG_DIR }}/{}.log ; test ${PIPESTATUS[0]} -eq 0) || (echo "$output" && exit 1)'
 # Cron will send email if there is any stdout or stderr output regardless of the
 # response code, so by only including output for failed tasks in the output, an
 # email will only be sent out if and only if one or more backup pruners failed.
 echo "$jobs" | tail -n +2 | parallel --no-notice -j0 --joblog {{ JOB_LOG }} $task
+status=$?
+
+if [ $status -eq 0 ]
+then
+  curl {{ BACKUP_PRUNER_SNITCH }}
+fi
+
+exit $status

--- a/templates/logrotate.conf
+++ b/templates/logrotate.conf
@@ -1,0 +1,11 @@
+{% for item in TARSNAPPER_JOBS %}
+{{ LOG_DIR }}/{{ item.name }}.log {
+        weekly
+        rotate 10
+        compress
+        delaycompress
+        missingok
+        notifempty
+        create 644 root root
+}
+{% endfor %}

--- a/templates/run-tarsnapper.sh
+++ b/templates/run-tarsnapper.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
+# Ensure that tarsnap is accessible on the path when running as a
+# GNU Parallel task
+PATH=$PATH:/usr/local/bin
+
 KEY_FILE="/etc/tarsnap/{{ item.name }}.key"
 CACHE_DIR="/var/cache/tarsnap/{{ item.name }}"
 
 /usr/local/bin/tarsnap --fsck --keyfile ${KEY_FILE} \
  --cachedir ${CACHE_DIR} && \
-tarsnapper \
+/usr/local/bin/tarsnapper \
  -o keyfile ${KEY_FILE} -o cachedir  ${CACHE_DIR} \
  --target '{{ item.target }}' --deltas {{ item.deltas }} \
  - "$@"


### PR DESCRIPTION
This adds a script that runs all of the backup pruners and logs a report using GNU Parallel, as well as a cron job that runs this script twice daily.
If the pruning fails for any tarsnap keys, the logs for all of the failed pruner scripts will be collected and sent in one email.

@smarnach @itsjeyd 