### PR TITLE
Use master version of OpenCraft-maintained Ansible roles.

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,26 +9,26 @@
   src: https://github.com/kamaln7/ansible-swapfile
   version: 8eb0e18d90a7f25b6658fbf56bcba01b84a664fc
 
-- src: https://github.com/open-craft/ansible-tarsnap
-  name: pmbauer.tarsnap
+- name: pmbauer.tarsnap
+  src: https://github.com/open-craft/ansible-tarsnap
   version: d96b1e69ae6b930e0841d7b025a3070c408a23
 
 - name: backup-to-tarsnap
   src: https://github.com/open-craft/ansible-backup-to-tarsnap
-  version: '3d2f6f982ab02112ede9e39e1553b106e5079b87'
+  version: origin/master
 
 - name: common-server
   src: https://github.com/open-craft/ansible-common-server
-  version: '8423f76a12f5ade7bd008efffedfee12f9506259'
+  version: origin/master
 
 - name: configure-apt
   src: https://github.com/open-craft/ansible-configure-apt
-  version: 'origin/master'
+  version: origin/master
 
 - name: sanity-checker
   src: https://github.com/open-craft/ansible-sanity-checker/
-  version: '5387389cbb640e125595fd57e5ab787504a9537c'
+  version: origin/master
 
 - name: forward-server-mail
   src: https://github.com/open-craft/ansible-forward-server-mail
-  version: 'c252ef531802fecace6c0173e647e0a0f13df256'
+  version: origin/master


### PR DESCRIPTION
This is a lot easier to maintain, and we started doing this a while ago for our other repos.